### PR TITLE
Added copyright headers, move module/class-level comments

### DIFF
--- a/simulations/BasicNetwork.ned
+++ b/simulations/BasicNetwork.ned
@@ -1,9 +1,7 @@
 //
-// A basic CCN network for testing. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim.simulations;
@@ -14,6 +12,9 @@ import inbaversim.WirelessAccessRouter;
 import inbaversim.WirelessNode;
 import ned.DatarateChannel;
 
+//
+// A basic CCN network for testing.
+//
 network BasicNetwork
 {
     parameters:

--- a/simulations/SimpleIoTNetwork.ned
+++ b/simulations/SimpleIoTNetwork.ned
@@ -1,9 +1,7 @@
 //
-// A simple IoT CCN network. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 18-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim.simulations;
@@ -21,6 +19,9 @@ import inbaversim.WirelessSensorNode;
 import ned.DatarateChannel;
 
 
+//
+// A simple IoT CCN network.
+//
 network SimpleIoTNetwork
 {
     parameters:

--- a/simulations/SimpleNetwork.ned
+++ b/simulations/SimpleNetwork.ned
@@ -1,9 +1,7 @@
 //
-// A simple CCN network. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim.simulations;
@@ -18,6 +16,9 @@ import inbaversim.WirelessNode;
 import ned.DatarateChannel;
 
 
+//
+// A simple CCN network.
+//
 network SimpleNetwork
 {
     parameters:
@@ -27,9 +28,9 @@ network SimpleNetwork
 
         @statistic[fwdNetworkCacheHitRatio](source=fwdNetworkCacheHitRatio; record=min,max,count,last,vector);
         @statistic[fwdNetworkCacheMissRatio](source=fwdNetworkCacheMissRatio; record=min,max,count,last,vector);
-        
+
         @display("bgb=410,372");
-    
+
     submodules:
         accessRouter: AccessRouter {
             @display("p=90,217");

--- a/simulations/SimpleSensorNetwork.ned
+++ b/simulations/SimpleSensorNetwork.ned
@@ -1,9 +1,7 @@
 //
-// A simple CCN based sensor network. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 18-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim.simulations;
@@ -16,6 +14,9 @@ import inbaversim.WirelessSensorNode;
 import ned.DatarateChannel;
 
 
+//
+// A simple CCN based sensor network.
+//
 network SimpleSensorNetwork
 {
     parameters:

--- a/simulations/WirelessNetwork.ned
+++ b/simulations/WirelessNetwork.ned
@@ -1,9 +1,7 @@
 //
-// A simple CCN wireless network. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 22-sep-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim.simulations;
@@ -18,6 +16,9 @@ import inbaversim.WirelessNode;
 import ned.DatarateChannel;
 
 
+//
+// A simple CCN wireless network.
+//
 network WirelessNetwork
 {
     parameters:

--- a/src/AccessRouter.ned
+++ b/src/AccessRouter.ned
@@ -1,14 +1,15 @@
 //
-// A CCN wired access router to connect wired CCN 
-// nodes. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A CCN wired access router to connect wired CCN
+// nodes.
+//
 module AccessRouter extends Node
 {
     parameters:

--- a/src/CCNInternet.ned
+++ b/src/CCNInternet.ned
@@ -1,14 +1,15 @@
 //
-// A node that acts as the CCN Internet. Applications can be
-// deployed to simulate the nodes in the Internt. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 23-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A node that acts as the CCN Internet. Applications can be
+// deployed to simulate the nodes in the Internt.
+//
 module CCNInternet extends Node
 {
     parameters:
@@ -17,7 +18,7 @@ module CCNInternet extends Node
         // transports used in node
         int internetNumWiredTransports = default(0);
         int internetNumWirelessTransports = default(0);
-        
+
         // forwarder used in node
         string forwarder = default("RFC8569Forwarder");
 

--- a/src/ContentDownloadApp.cc
+++ b/src/ContentDownloadApp.cc
@@ -1,11 +1,9 @@
 //
-// A file download client (content requester) application that
-// implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "ContentDownloadApp.h"
 

--- a/src/ContentDownloadApp.h
+++ b/src/ContentDownloadApp.h
@@ -1,11 +1,9 @@
 //
-// A file download client (content requester) application that
-// implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_CONTENTDOWNLOADAPP_H_
 #define __INBAVERSIM_CONTENTDOWNLOADAPP_H_
@@ -24,6 +22,10 @@ using namespace std;
 class Demiurge;
 class Numen;
 
+/**
+ * A file download client (content requester) application that
+ * implements the IApplication interface.
+ */
 class ContentDownloadApp : public cSimpleModule
 {
   protected:

--- a/src/ContentDownloadApp.ned
+++ b/src/ContentDownloadApp.ned
@@ -1,14 +1,15 @@
 //
-// A file download client (content requester) application that 
-// implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A file download client (content requester) application that
+// implements the IApplication interface.
+//
 simple ContentDownloadApp like IApplication
 {
     parameters:
@@ -35,12 +36,12 @@ simple ContentDownloadApp like IApplication
         @signal[appContentDownloadDuration](type=simtime_t);
         @signal[appSegmentDownloadDuration](type=simtime_t);
         @signal[appTotalInterestsBytesSent](type=long);
-        @signal[appRetransmissionInterestsBytesSent](type=long);        
+        @signal[appRetransmissionInterestsBytesSent](type=long);
         @signal[appTotalContentObjsBytesReceived](type=long);
         @signal[appTotalDataBytesReceived](type=long);
         @signal[appNetworkInterestRetransmissionCount](type=long);
         @signal[appNetworkInterestInjectedCount](type=long);
-        
+
         // display icon
         @display("i=block/app");
 

--- a/src/ContentHostApp.cc
+++ b/src/ContentHostApp.cc
@@ -1,11 +1,9 @@
 //
-// A file hosting (content server) application that
-// implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "ContentHostApp.h"
 

--- a/src/ContentHostApp.h
+++ b/src/ContentHostApp.h
@@ -1,11 +1,9 @@
 //
-// A file hosting (content server) application that
-// implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_CONTENTHOSTAPP_H_
 #define __INBAVERSIM_CONTENTHOSTAPP_H_
@@ -26,6 +24,10 @@ using namespace std;
 
 class Demiurge;
 
+/**
+ * A file hosting (content server) application that
+ * implements the IApplication interface.
+ */
 class ContentHostApp : public cSimpleModule
 {
 

--- a/src/ContentHostApp.ned
+++ b/src/ContentHostApp.ned
@@ -1,14 +1,15 @@
 //
-// A file hosting (content server) application that 
-// implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A file hosting (content server) application that
+// implements the IApplication interface.
+//
 simple ContentHostApp like IApplication
 {
     parameters:
@@ -17,7 +18,7 @@ simple ContentHostApp like IApplication
         string dataNamePrefix = default("file");
         volatile int segmentSize @unit(byte) = default(10000byte);
         volatile int numSegmentsPerFile = default(intuniform(5, 100));
-        volatile double cacheTime @unit(s) = default(3600s); // 0 means infinite 
+        volatile double cacheTime @unit(s) = default(3600s); // 0 means infinite
 
         // statistic signals
         @signal[appTotalInterestsBytesReceived](type=long);

--- a/src/ContentServer.ned
+++ b/src/ContentServer.ned
@@ -1,13 +1,14 @@
 //
-// A CCN content server hosting applications. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A CCN content server hosting applications.
+//
 module ContentServer extends Node
 {
     parameters:

--- a/src/CoreRouter.ned
+++ b/src/CoreRouter.ned
@@ -1,14 +1,15 @@
 //
-// A CCN root router that routes between content providers 
-// and propagates prefixes. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A CCN root router that routes between content providers
+// and propagates prefixes.
+//
 module CoreRouter extends Node
 {
     parameters:
@@ -17,7 +18,7 @@ module CoreRouter extends Node
         // transports used in node
         int coreRouterNumWiredTransports = default(0);
         int coreRouterNumWirelessTransports = default(0);
-        
+
         // forwarder used in node
         string forwarder = default("RFC8569Forwarder");
 

--- a/src/Demiurge.cc
+++ b/src/Demiurge.cc
@@ -1,11 +1,9 @@
 //
-// The global control module of a CCN network. Only one
-// of these instances are created in a simulation.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "Demiurge.h"
 

--- a/src/Demiurge.h
+++ b/src/Demiurge.h
@@ -1,11 +1,9 @@
 //
-// The global control module of a CCN network. Only one
-// of these instances are created in a simulation.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_DEMIURGE_H_
 #define __INBAVERSIM_DEMIURGE_H_
@@ -16,6 +14,10 @@
 using namespace omnetpp;
 using namespace std;
 
+/**
+ * The global control module of a CCN network. Only one
+ * of these instances are created in a simulation.
+ */
 class Demiurge : public cSimpleModule
 {
     private:

--- a/src/Demiurge.ned
+++ b/src/Demiurge.ned
@@ -1,14 +1,15 @@
 //
-// The global control module of a CCN network. Only one
-// of these instances are created in a simulation.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// The global control module of a CCN network. Only one
+// of these instances are created in a simulation.
+//
 simple Demiurge
 {
     parameters:

--- a/src/IApplication.ned
+++ b/src/IApplication.ned
@@ -1,13 +1,14 @@
 //
-// Interface of a CCN application.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// Interface of a CCN application.
+//
 moduleinterface IApplication
 {
     parameters:

--- a/src/IForwarder.ned
+++ b/src/IForwarder.ned
@@ -1,12 +1,14 @@
 //
-// Interface of a CCN forwarder.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 package inbaversim;
 
+//
+// Interface of a CCN forwarder.
+//
 moduleinterface IForwarder
 {
     parameters:

--- a/src/ITransport.ned
+++ b/src/ITransport.ned
@@ -1,13 +1,14 @@
 //
-// Interface of a CCN transport.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 package inbaversim;
 
-
+//
+// Interface of a CCN transport.
+//
 moduleinterface ITransport
 {
     parameters:

--- a/src/InternalMessages.msg
+++ b/src/InternalMessages.msg
@@ -1,26 +1,28 @@
 //
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+//
 // The formats of all the messages used internally by a node to
 // communication between models.
-//
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
 //
 
 //
 // Format of app registration msg (sent by any app to forwarder).
 //
 packet AppRegistrationMsg {
-    
+
     // ID that uniquely identifies the registering app
     long appID;
-    
+
     // is it a content server or a client application?
     bool contentServerApp;
-    
+
     // if content server, the prefixs for which content exist
     string hostedPrefixNames[];
-    
+
     // a description
     string appDescription;
 }
@@ -50,7 +52,7 @@ packet PrefixRegistrationMsg {
 
     // prefix to register
     string prefixName;
-    
+
     // face ID of the face to use as the outgoing face
     long faceID;
 }
@@ -61,7 +63,7 @@ packet PrefixRegistrationMsg {
 // transports to the forwrder.
 //
 packet NeighbourListMsg {
-    
+
     // ID that uniquely identifies the transport
     long transportID;
 

--- a/src/IoTGateway.ned
+++ b/src/IoTGateway.ned
@@ -1,15 +1,16 @@
 //
-// A CCN based IoT gatewway with 2 network interfaces - a
-// LoRa interface facing a sensor network and an Ethernet 
-// interface facing the internet.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 18-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A CCN based IoT gatewway with 2 network interfaces - a
+// LoRa interface facing a sensor network and an Ethernet
+// interface facing the internet.
+//
 module IoTGateway extends Node
 {
     parameters:
@@ -18,7 +19,7 @@ module IoTGateway extends Node
         // number of transports
         int iotGatewayNumWiredTransports = default(1);
         int iotGatewayNumWirelessTransports = default(1);
-                
+
         // forwarder used in node
         string forwarder = default("RFC8569Forwarder");
 

--- a/src/IoTGatewayApp.cc
+++ b/src/IoTGatewayApp.cc
@@ -1,12 +1,9 @@
 //
-// An application that connects an IoT with the Internet
-// and is able to handle the functionality required to
-// manage the duty cycled IoT and the permently-on
-// Internet. It implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 19-feb-2023
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
+
 
 #include "IoTGatewayApp.h"
 

--- a/src/IoTGatewayApp.h
+++ b/src/IoTGatewayApp.h
@@ -1,13 +1,9 @@
 //
-// An application that connects an IoT with the Internet
-// and is able to handle the functionality required to
-// manage the duty cycled IoT and the permently-on
-// Internet. It implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 19-feb-2023
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_IOTGATEWAYAPP_H_
 #define __INBAVERSIM_IOTGATEWAYAPP_H_
@@ -28,6 +24,12 @@ using namespace std;
 
 class Demiurge;
 
+/**
+ * An application that connects an IoT with the Internet
+ * and is able to handle the functionality required to
+ * manage the duty cycled IoT and the permently-on
+ * Internet. It implements the IApplication interface.
+ */
 class IoTGatewayApp : public cSimpleModule
 {
 

--- a/src/IoTGatewayApp.ned
+++ b/src/IoTGatewayApp.ned
@@ -1,19 +1,20 @@
 //
-// An application that serves sensor data to the outside world
-// and is able to receive and store sensor data from the local
-// IoT. It implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 19-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// An application that serves sensor data to the outside world
+// and is able to receive and store sensor data from the local
+// IoT. It implements the IApplication interface.
+//
 simple IoTGatewayApp like IApplication
 {
     parameters:
-        
+
         // Prefix hosted at the gateway for outside world to access sensor data
         string hostedPrefixName = default("ccnx://uni-bremen.de/ee/iot/");
 
@@ -25,7 +26,7 @@ simple IoTGatewayApp like IApplication
 
         // lifetime of a interest sent to the sensor network
         double interestLifetime @unit(s) = default(2s);
-        
+
         // maximum historical sensor reading to hold
         int maximumSensorReadingsToKeep = default(50);
 

--- a/src/Node.ned
+++ b/src/Node.ned
@@ -1,15 +1,16 @@
 //
-// A CCN node containing the CCN protocol stack. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
 import inet.mobility.contract.IMobility;
 
+//
+// A CCN node containing the CCN protocol stack.
+//
 module Node
 {
     parameters:

--- a/src/Numen.cc
+++ b/src/Numen.cc
@@ -1,12 +1,9 @@
 //
-// The node specific control module of a CCN node. Only one
-// of these instances are created in a simulation for every
-// node.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "Numen.h"
 

--- a/src/Numen.h
+++ b/src/Numen.h
@@ -1,12 +1,9 @@
 //
-// The node specific control module of a CCN node. Only one
-// of these instances are created in a simulation for every
-// node.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_NUMEN_H_
 #define __INBAVERSIM_NUMEN_H_
@@ -15,6 +12,11 @@
 
 using namespace omnetpp;
 
+/**
+ * The node specific control module of a CCN node. Only one
+ * of these instances are created in a simulation for every
+ * node.
+ */
 class Numen : public cSimpleModule
 {
   protected:

--- a/src/Numen.ned
+++ b/src/Numen.ned
@@ -1,13 +1,14 @@
 //
-// The control module of a CCN node.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// The control module of a CCN node.
+//
 simple Numen
 {
     parameters:

--- a/src/RFC8569Forwarder.cc
+++ b/src/RFC8569Forwarder.cc
@@ -1,11 +1,9 @@
 //
-// A CCN forwarder implementing the RFC 8569 using the
-// IForwarder interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "RFC8569Forwarder.h"
 

--- a/src/RFC8569Forwarder.h
+++ b/src/RFC8569Forwarder.h
@@ -1,11 +1,9 @@
 //
-// A CCN forwarder implementing the RFC 8569 using the
-// IForwarder interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_RFC8569FORWARDER_H_
 #define __INBAVERSIM_RFC8569FORWARDER_H_
@@ -27,6 +25,10 @@ using namespace std;
 class Demiurge;
 class Numen;
 
+/**
+ * A CCN forwarder implementing the RFC 8569 using the
+ * IForwarder interface.
+ */
 class RFC8569Forwarder : public cSimpleModule
 {
   protected:

--- a/src/RFC8569Forwarder.ned
+++ b/src/RFC8569Forwarder.ned
@@ -1,14 +1,15 @@
 //
-// A CCN forwarder implementing the RFC 8569 using the
-// IForwarder interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A CCN forwarder implementing the RFC 8569 using the
+// IForwarder interface.
+//
 //
 // TODO auto-generated module
 //

--- a/src/RFC8609Messages.msg
+++ b/src/RFC8609Messages.msg
@@ -1,10 +1,12 @@
 //
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+//
 // The formats of all the messages defined in RFC 8609 for
 // communications between CCN nodes.
-//
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
 //
 
 //
@@ -34,7 +36,7 @@ packet InterestMsg
     // no security aspects incorporated yet
 
 
-    //====== Others fields used only by simulator 
+    //====== Others fields used only by simulator
 
     // msg sizes in bytes
     int headerSize;
@@ -42,7 +44,7 @@ packet InterestMsg
 
     // hops
     int hopsTravelled;
-    
+
     // arrival face ID and type at the forwarding (CCN) layer
     long arrivalFaceID;
     int arrivalFaceType;
@@ -76,7 +78,7 @@ packet ContentObjMsg
     // no security aspects incorporated yet
 
 
-    //====== Others fields used only by simulator 
+    //====== Others fields used only by simulator
 
     // msg sizes in bytes
     int headerSize;
@@ -109,7 +111,7 @@ enum ReturnCodeTypes
 packet InterestRtnMsg
 {
 
-    //====== Return Code 
+    //====== Return Code
 
     // return reason
     int returnCode @enum(ReturnCodeTypes);
@@ -124,7 +126,7 @@ packet InterestRtnMsg
     string versionName;
     int segmentNum;
 
-    //====== Others fields used only by simulator 
+    //====== Others fields used only by simulator
 
     // msg sizes in bytes
     int headerSize;

--- a/src/SensingApp.cc
+++ b/src/SensingApp.cc
@@ -1,11 +1,9 @@
 //
-// A file hosting (content server) application that
-// implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "SensingApp.h"
 

--- a/src/SensingApp.h
+++ b/src/SensingApp.h
@@ -1,12 +1,9 @@
 //
-// A generic sensing application that is able to be
-// configured to return different data values of
-// sensors. It implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 18-feb-2023
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_SENSINGAPP_H_
 #define __INBAVERSIM_SENSINGAPP_H_
@@ -27,6 +24,11 @@ using namespace std;
 
 class Demiurge;
 
+/**
+ * A generic sensing application that is able to be
+ * configured to return different data values of
+ * sensors. It implements the IApplication interface.
+ */
 class SensingApp : public cSimpleModule
 {
 

--- a/src/SensingApp.ned
+++ b/src/SensingApp.ned
@@ -1,21 +1,22 @@
 //
-// A generic sensing application that is able to be
-// configured to return different data values of 
-// sensors. It implements the IApplication interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 18-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A generic sensing application that is able to be
+// configured to return different data values of
+// sensors. It implements the IApplication interface.
+//
 simple SensingApp like IApplication
 {
     parameters:
         // Prefix served by the this sensor expecting the gw to request for data - the sensor name is appended at the end
         string sensorPrefixName = default("ccnx://uni-bremen.de/ee/sensor/");
-        
+
         // Prefix used by this sensor to inform GW its presence and asking to send request for the sensor data
         string gwPrefixName = default("ccnx://uni-bremen.de/ee/gw/");
 
@@ -25,19 +26,19 @@ simple SensingApp like IApplication
         // details of the segments
         volatile int segmentSize @unit(byte) = default(24byte);
         volatile int numSegmentsPerFile = default(1);
-        
+
         // duration of validity of a data item
         volatile double cacheTime @unit(s) = default(900s); // 0 means infinite
-        
+
         // types of data sensed
         string sensedDataTypes = default("temperature;humidity;vwc;salinity;water;electricity");
 
         // parameters for temperature sensing
         volatile double temperature = default(uniform(5.0, 7.0)); // celsius
-        
+
         // parameters for humidity sensing
         volatile double humidity = default(uniform(45.0, 60.0)); // percetage
-        
+
         // parameters for volumetric water content sensing
         volatile double vwc = default(uniform(20.0, 30.0)); // percentage
 
@@ -47,11 +48,11 @@ simple SensingApp like IApplication
         // parameters for water meter sensing (waterIncrease must be based on wakeupInterval)
         double waterStart = default(uniform(10000, 20000)); // stating meter reading in liters
         volatile double waterIncrease = default(uniform(0.04, 0.06)); // meter increae amount in liters
-        
+
         // parameters for electricity meter sensing (electricIncrease must be based on wakeupInterval)
         double electricStart = default(uniform(8000, 10000)); // starting meter reading, in kWh
         volatile double electricIncrease = default(uniform(0.0025, 0.005)); // meter increae amount in kWh
-        
+
         // duty cycling info
         volatile double wakeupInterval @unit(s) = default(10s);
 

--- a/src/ThingsApp.cc
+++ b/src/ThingsApp.cc
@@ -1,12 +1,9 @@
 //
-// A simple application to retrieve data from a sensor network
-// managed by a gateway, that implements the IApplication
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 24-feb-2023
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "ThingsApp.h"
 

--- a/src/ThingsApp.h
+++ b/src/ThingsApp.h
@@ -1,12 +1,9 @@
 //
-// A simple application to retrieve data from a sensor network
-// managed by a gateway, that implements the IApplication
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 24-feb-2023
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_THINGSAPP_H_
 #define __INBAVERSIM_THINGSAPP_H_
@@ -25,6 +22,11 @@ using namespace std;
 class Demiurge;
 class Numen;
 
+/**
+ * A simple application to retrieve data from a sensor network
+ * managed by a gateway, that implements the IApplication
+ * interface.
+ */
 class ThingsApp : public cSimpleModule
 {
   protected:

--- a/src/ThingsApp.ned
+++ b/src/ThingsApp.ned
@@ -1,15 +1,16 @@
 //
-// A simple application to retrieve data from a sensor network
-// managed by a gateway, that implements the IApplication 
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 24-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A simple application to retrieve data from a sensor network
+// managed by a gateway, that implements the IApplication
+// interface.
+//
 simple ThingsApp like IApplication
 {
     parameters:
@@ -25,7 +26,7 @@ simple ThingsApp like IApplication
 
         // lifetime of a data request interest
         volatile double interestLifetime @unit(s) = default(10s);
-        
+
         // names of the types of sensor data retrieved and random variable to select on each time
         string sensorDataNames = default("temperature;humidity;vwc;salinity;water;electricity");
         volatile int nextIndexOfSensorDataToRetrieve = default(intuniform(0, 6));
@@ -40,12 +41,12 @@ simple ThingsApp like IApplication
         @signal[appContentDownloadDuration](type=simtime_t);
         @signal[appSegmentDownloadDuration](type=simtime_t);
         @signal[appTotalInterestsBytesSent](type=long);
-        @signal[appRetransmissionInterestsBytesSent](type=long);        
+        @signal[appRetransmissionInterestsBytesSent](type=long);
         @signal[appTotalContentObjsBytesReceived](type=long);
         @signal[appTotalDataBytesReceived](type=long);
         @signal[appNetworkInterestRetransmissionCount](type=long);
         @signal[appNetworkInterestInjectedCount](type=long);
-        
+
         // display icon
         @display("i=block/app");
 

--- a/src/TransportMessages.msg
+++ b/src/TransportMessages.msg
@@ -1,9 +1,7 @@
 //
-// Formats of messages used by transports
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 //

--- a/src/WiredNode.ned
+++ b/src/WiredNode.ned
@@ -1,13 +1,14 @@
 //
-// A wired CCN node with one wired interface. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A wired CCN node with one wired interface.
+//
 module WiredNode extends Node
 {
     parameters:

--- a/src/WiredTransport.cc
+++ b/src/WiredTransport.cc
@@ -1,11 +1,9 @@
 //
-// A wired transport that implements the ITransport
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "WiredTransport.h"
 

--- a/src/WiredTransport.h
+++ b/src/WiredTransport.h
@@ -1,11 +1,9 @@
 //
-// A wired transport that implements the ITransport
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_WIREDTRANSPORT_H_
 #define __INBAVERSIM_WIREDTRANSPORT_H_
@@ -26,6 +24,10 @@ using namespace std;
 class Demiurge;
 class Numen;
 
+/**
+ * A wired transport that implements the ITransport
+ * interface.
+ */
 class WiredTransport : public cSimpleModule
 {
   protected:

--- a/src/WiredTransport.ned
+++ b/src/WiredTransport.ned
@@ -1,14 +1,15 @@
 //
-// A wired transport that implements the ITransport
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A wired transport that implements the ITransport
+// interface.
+//
 simple WiredTransport like ITransport
 {
     parameters:

--- a/src/WirelessAccessRouter.ned
+++ b/src/WirelessAccessRouter.ned
@@ -1,14 +1,15 @@
 //
-// A CCN wireless access router to connect WLAN based 
-// CCN nodes. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
 
+//
+// A CCN wireless access router to connect WLAN based
+// CCN nodes.
+//
 module WirelessAccessRouter extends Node
 {
     parameters:
@@ -17,7 +18,7 @@ module WirelessAccessRouter extends Node
         // number of transports
         int wirelessAccessRouterNumWiredTransports = default(1);
         int wirelessAccessRouterNumWirelessTransports = default(1);
-                
+
         // forwarder used in node
         string forwarder = default("RFC8569Forwarder");
 

--- a/src/WirelessNode.ned
+++ b/src/WirelessNode.ned
@@ -1,10 +1,7 @@
 //
-// A wireless CCN node with two network interfaces, one
-// WLAN and the other Bluetooth. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
@@ -12,6 +9,10 @@ package inbaversim;
 //import inet.mobility.static.StationaryMobility;
 //import inet.mobility.base.MobilityBase;
 
+//
+// A wireless CCN node with two network interfaces, one
+// WLAN and the other Bluetooth.
+//
 module WirelessNode extends Node
 {
     parameters:
@@ -20,25 +21,25 @@ module WirelessNode extends Node
         // transports used in node
         int wirelessNodeNumWiredTransports = default(0);
         int wirelessNodeNumWirelessTransports = default(2);
-        
+
         // forwarder used in node
         string forwarder = default("RFC8569Forwarder");
-        
+
         // WLAN transport parameters
         string wlanConnectString = default("ccn");
         double wlanWirelessRange @unit(meter) = default(10m);
         double wlanDataRate @unit(bps) = default(1e6bps);
         double wlanPacketErrorRate @unit(pct) = default(0.0pct);
 
-        // Bluetooth transport settings         
+        // Bluetooth transport settings
         string btConnectString = default("ccn");
         double btWirelessRange @unit(meter) = default(10m);
         double btDataRate @unit(bps) = default(1e6bps);
         double btPacketErrorRate @unit(pct) = default(0.0pct);
-        
+
         // mobility model settings
         string mobility = default("StationaryMobility");
-        
+
         // set forwarder used
         fwd.typename = forwarder;
 

--- a/src/WirelessSensorNode.ned
+++ b/src/WirelessSensorNode.ned
@@ -1,10 +1,7 @@
 //
-// A wireless sensor node that communicates over CCN. It has one
-// LoRa wireless network interface. 
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 18-feb-2023
-//
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 
 package inbaversim;
@@ -13,6 +10,10 @@ import inbaversim.Node;
 import inbaversim.WirelessTransport;
 
 
+//
+// A wireless sensor node that communicates over CCN. It has one
+// LoRa wireless network interface.
+//
 module WirelessSensorNode extends Node
 {
     parameters:
@@ -20,7 +21,7 @@ module WirelessSensorNode extends Node
 
         // transports used in node
         int wirelessSensorNodeLoRaNumWirelessTransports = default(1);
-        
+
         // forwarder used in node
         string forwarder = default("RFC8569Forwarder");
 
@@ -43,10 +44,10 @@ module WirelessSensorNode extends Node
         double wirelessSensorNodeLoRaDataRate @unit(bps) = default(5.5kbps);
         double wirelessSensorNodeLoRaPacketErrorRate @unit(pct) = default(0.0pct);
         int wirelessSensorNodeLoRaHeaderSize @unit(byte) = default(20byte);
-        
+
         // mobility model settings
         string mobility = default("StationaryMobility");
-        
+
         // set forwarder used
         fwd.typename = forwarder;
 

--- a/src/WirelessTransport.cc
+++ b/src/WirelessTransport.cc
@@ -1,11 +1,9 @@
 //
-// A wireless transport that implements the ITransport
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #include "WirelessTransport.h"
 

--- a/src/WirelessTransport.h
+++ b/src/WirelessTransport.h
@@ -1,11 +1,9 @@
 //
-// A wireless transport that implements the ITransport
-// interface.
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
-//
+
 
 #ifndef __INBAVERSIM_WIRELESSTRANSPORT_H_
 #define __INBAVERSIM_WIRELESSTRANSPORT_H_
@@ -25,6 +23,10 @@ using namespace std;
 class Demiurge;
 class Numen;
 
+/**
+ * A wireless transport that implements the ITransport
+ * interface.
+ */
 class WirelessTransport : public cSimpleModule
 {
     protected:

--- a/src/WirelessTransport.ned
+++ b/src/WirelessTransport.ned
@@ -1,23 +1,25 @@
 //
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+package inbaversim;
+
+//
 // A wireless transport that implements the ITransport
 // interface.
 //
-// @author : Asanga Udugama (adu@comnets.uni-bremen.de)
-// @date   : 31-mar-2021
-//
-//
-package inbaversim;
-
 simple WirelessTransport like ITransport
 {
     parameters:
-        
+
         // wireless technology -> WLAN, Bluetooth
         string wirelessTechnology = default("WLAN");
 
         // wireless mode of operation -> ap, client, direct
         string operationMode = default("client");
-        
+
         // wireless connection string - for ap, client
         string connectString = default("ccn");
 
@@ -36,7 +38,7 @@ simple WirelessTransport like ITransport
 
         // header size
         int headerSize @unit(byte) = default(32byte);
-        
+
         // whether to show and the color of the circle drawn for the wireless range
         bool wirelessRangeRadiusShow = default(false);
         string wirelessRangeRadiusColor = default("black");
@@ -52,5 +54,5 @@ simple WirelessTransport like ITransport
         inout forwarderInOut;
         inout physicalInOut;
         input radioIn @directIn;
-    
+
 }

--- a/src/inbaver.h
+++ b/src/inbaver.h
@@ -1,3 +1,8 @@
+//
+// Copyright (C) 2021 Asanga Udugama (adu@comnets.uni-bremen.de)
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
 
 #ifndef INBAVER_H_
 #define INBAVER_H_


### PR DESCRIPTION
Documentation tools like C++ Doxygen and NED's NEDDOC (IDE: Project -> Generate NED documentation...) expect to find docu comments right above the class/module declarations. The top of sources files customarily contain copyright comments. The source files were adjusted accordingly -- take it over if you like this change.